### PR TITLE
修复IE9+宽度样式异常问题

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # history
 
+## 0.2.6
+
+* `FIXED` ie9+ result panel width style error
+
 ## 0.2.3
 
 * `FIXED` footer's button click, dropdown not hidden

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "uxcore-cascade-multi-select",
- "version": "0.2.5",
+ "version": "0.2.6",
  "description": "uxcore-cascade-multi-select component for uxcore.",
  "repository": "https://github.com/uxcore/uxcore-cascade-multi-select.git",
  "author": "eternalsky",

--- a/src/CascadeMultiPanel.jsx
+++ b/src/CascadeMultiPanel.jsx
@@ -329,21 +329,10 @@ class CascadeMulti extends React.Component {
    * 设置组件宽度样式，兼容名称过长时显示效果等
    */
   setPanelWidth() {
-    const { cascadeSize } = this.props;
-    const style = {};
     const reg = /[0-9]+/g;
-    const width = this.refUls ?
-      getComputedStyle(this.refUls).width.match(reg)[0] :
-      150;
     const resultPanelWidth = this.refResultPanel ?
       getComputedStyle(this.refResultPanel).width.match(reg)[0] : 220;
-    style.width = 0;
-    for (let i = 0; i < cascadeSize; i += 1) {
-      style.width += parseInt(width, 0);
-    }
-    style.width += parseInt(resultPanelWidth, 0) + 2;
     this.resultPanelWidth = parseInt(resultPanelWidth, 0);
-    return style;
   }
 
   /**
@@ -606,6 +595,7 @@ class CascadeMulti extends React.Component {
     for (let i = 0; i < cascadeSize; i += 1) {
       arr.push(this.renderUlList(i));
     }
+    this.setPanelWidth();
     return (
       <div
         className={classnames({
@@ -614,7 +604,6 @@ class CascadeMulti extends React.Component {
         onClick={(e) => {
           e.stopPropagation();
         }}
-        style={this.setPanelWidth()}
       >
         {arr}
         {this.renderResult()}

--- a/src/CascadeMultiPanel.jsx
+++ b/src/CascadeMultiPanel.jsx
@@ -592,8 +592,10 @@ class CascadeMulti extends React.Component {
   render() {
     const { className, prefixCls, cascadeSize } = this.props;
     const arr = [];
+    let minWidth = 0;
     for (let i = 0; i < cascadeSize; i += 1) {
       arr.push(this.renderUlList(i));
+      minWidth = 150 * cascadeSize + 222;
     }
     this.setPanelWidth();
     return (
@@ -604,6 +606,7 @@ class CascadeMulti extends React.Component {
         onClick={(e) => {
           e.stopPropagation();
         }}
+        style={{ minWidth }}
       >
         {arr}
         {this.renderResult()}

--- a/src/CascadeMultiSelect.less
+++ b/src/CascadeMultiSelect.less
@@ -11,6 +11,7 @@
 .@{notificationPrefixCls} {
   position: relative;
 
+  display: inline-block;
   overflow: hidden;
 
   cursor: auto;
@@ -75,17 +76,18 @@
   }
 
   .@{notificationPrefixCls}-result {
-    float: right;
+    float: left;
 
     width: 220px;
     height: 310px;
-    padding: 20px 15px;
+    padding: 0;
 
     border-left: 1px solid @border-color;
     background-color: #fff;
 
     .@{notificationPrefixCls}-result-title {
-      padding-bottom: 10px;
+      margin: 20px 15px 10px 15px;
+      padding: 0;
 
       color: #999;
 
@@ -105,7 +107,7 @@
       overflow-y: auto;
 
       height: 250px;
-      margin: 0 -15px;
+      margin: 0;
       ul {
         -webkit-user-select: none;
         -moz-user-select: none;
@@ -263,8 +265,8 @@
         }
         &-content {
           transition: margin .3s cubic-bezier(.165,.84,.44,1);
-          -ms-transform: scale(0);
-          transform: scale(0);
+          -ms-transform: scale(1);
+          transform: scale(1);
         }
         &-remove {
           position: absolute;


### PR DESCRIPTION
调整了result panel的样式设置，调整后ie9+不会再出现结果列布局混乱的情况。
计算设置了面板最小宽度，以保证样式不会被宽度缩小时设置布局混乱。
去除了部分设置样式的代码。
更新了HISTORY，package.json版本号为0.2.6